### PR TITLE
authorized_keys mounted as volume and all env variables in one place

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+LETSENCRYPT_HOST=<replace.this.example.com>
+LETSENCRYPT_EMAIL=<replace.with.your@email.com>
+
+# Letsencrypt has a pretty strict rate limit of 5 per week, so if you
+# find yourself needing to debug things, uncomment this line:
+#LETSENCRYPT_TEST=true
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,6 @@ RUN \
   chown -R tunnel:tunnel /home/tunnel && \
   ssh-keygen -A
 
-COPY --chown=tunnel:tunnel identity.pub /home/tunnel/.ssh/authorized_keys
-
-RUN chmod 644 /home/tunnel/.ssh/authorized_keys
+VOLUME /home/tunnel/.ssh/authorized_keys
 
 CMD /usr/sbin/sshd -D

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN \
   chown -R tunnel:tunnel /home/tunnel && \
   ssh-keygen -A
 
-COPY identity.pub /home/tunnel/.ssh/authorized_keys
+COPY --chown=tunnel:tunnel identity.pub /home/tunnel/.ssh/authorized_keys
+
+RUN chmod 644 /home/tunnel/.ssh/authorized_keys
 
 CMD /usr/sbin/sshd -D

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,9 @@ services:
     environment:
       - VIRTUAL_HOST=${LETSENCRYPT_HOST}
       - VIRTUAL_PORT=8080 # needs to be higher than 1024 for ssh to be able to reverse forward
-      - LETSENCRYPT_HOST=${LETSENCRYPT_HOST}
-      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
-      # - LETSENCRYPT_TEST=true
+      - LETSENCRYPT_HOST
+      - LETSENCRYPT_EMAIL
+      - LETSENCRYPT_TEST
 
   nginx-proxy:
     image: jwilder/nginx-proxy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - LETSENCRYPT_HOST
       - LETSENCRYPT_EMAIL
       - LETSENCRYPT_TEST
+    volumes:
+      - ./identity.pub:/home/tunnel/.ssh/authorized_keys
 
   nginx-proxy:
     image: jwilder/nginx-proxy

--- a/environment
+++ b/environment
@@ -1,2 +1,0 @@
-export LETSENCRYPT_HOST=replace.this.example.com
-export LETSENCRYPT_EMAIL=replace.with.your@email.com

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,11 @@ A server running docker with a DNS name pointing to it. (If you don't already ha
 The following instructions  assume you're using docker-machine. This will definitely work without it, but you'll have to do a bit more manual copying of files. And you'll probably want to clone the repo on your server rather than locally. 
 
 - Clone this repo
-- Replace identity.pub with your own public SSH key.
+- Replace the content of `identity.pub` with your own SSH public key.
+- Adjust file permissions:
+```
+chmod 644 identity.pub
+```
 - Rename the `.env.sample` file to `.env`and int it replace `replace.this.example.com` with the DNS name of your server and `replace.with.your@email.com` with your email. Letsencrypt has a pretty strict rate limit of 5 per week, so if you find yourself needing to debug things, uncomment the line `LETSENCRYPT_TEST=true`. The test certs will by considered unsecure by browsers but it should let you test the basic functionality without hitting the rate limit.
 - Then to launch the docker containers:
 ```
@@ -19,5 +23,3 @@ The following instructions  assume you're using docker-machine. This will defini
   ./start_tunnel.sh 3000 whatever.your.domain.is
 ```
 - Open browser to whatever.your.domain.is and you should see an "It works!"
-
-If you need to make tunnel configuration changes (such as changing your public key), you'll likely need to remove the existing `ssh-reverse-tunnel` image to force it to rebuild.

--- a/readme.md
+++ b/readme.md
@@ -1,18 +1,16 @@
 
 ## To run this example you will need:
 
-A server running docker with a DNS name pointing to it. (If you don't already have one setup, using [docker-machine]( https://docs.docker.com/machine/get-started-cloud/#examples)) can make it easier to setup and deploy to your server. Your server will need ports 80, 443, and 2222 open to the public.
+A server running docker with a DNS name pointing to it. (If you don't already have one setup, using [docker-machine]( https://docs.docker.com/machine/get-started-cloud/#examples) can make it easier to setup and deploy to your server.) Your server will need ports 80, 443, and 2222 open to the public.
 
 The following instructions  assume you're using docker-machine. This will definitely work without it, but you'll have to do a bit more manual copying of files. And you'll probably want to clone the repo on your server rather than locally. 
 
 - Clone this repo
 - Replace identity.pub with your own public SSH key.
-- Edit the `environment` file and replace `replace.this.example.com` with the DNS name of your server and `replace.with.your@email.com` with your email.
-- Letsencrypt has a pretty strict rate limit of 5 per week, so if you find yourself needing to debug things, uncomment the line `LETSENCRYPT_TEST=true` in the  docker-compose.yml file. The test certs will by considered unsecure by browsers but it should let you test the basic functionality without hitting the rate limit.
+- Rename the `.env.sample` file to `.env`and int it replace `replace.this.example.com` with the DNS name of your server and `replace.with.your@email.com` with your email. Letsencrypt has a pretty strict rate limit of 5 per week, so if you find yourself needing to debug things, uncomment the line `LETSENCRYPT_TEST=true`. The test certs will by considered unsecure by browsers but it should let you test the basic functionality without hitting the rate limit.
 - Then to launch the docker containers:
 ```
   eval $(docker-machine env your-server-name)
-  source environment
   docker-compose up
 ```
 - Now on your local machine you can test the tunnel with something like:


### PR DESCRIPTION
I had a problem to open the tunnel connection. Would always get a password prompt. Turns out it was an issue with not having strict enough permissions on the `authorized_keys` file.

Fixed that and, while I was at it, did some other enhancements:

- Decoupled the authorized_keys from the container image. Now it is mounted as a volume. This eliminates the necessity to rebuild de image for identity updates.
- Changed the environment file to `.env` which is automatically evaluated by Docker Compose and put all base variables in there. This way only the one file has to be edited to setup the service.